### PR TITLE
Minor update - fixed typo in echo statement in entrypoint.sh

### DIFF
--- a/compare-action/entrypoint.sh
+++ b/compare-action/entrypoint.sh
@@ -78,7 +78,7 @@ python -m piperider_cli.recipes.github_action prepare_for_action
 run_commands=$(python -m piperider_cli.recipes.github_action make_recipe_command)
 IFS=$'\n'
 for cmd in $run_commands; do
-    echo "[PipeRider] CMD Execlute => $cmd"
+    echo "[PipeRider] CMD Execute => $cmd"
     eval $cmd ; rc=$?
 done
 


### PR DESCRIPTION
I am implemented piperider in github actions for a private repo. While working on this, I noticed a small typo in an echo command in entrypoint.sh. 

I love this action and am excited to start using it!